### PR TITLE
Change packets to not hex or pickle data, and instead send as pure json objects to allow easier cross-platform clients

### DIFF
--- a/networking/models.py
+++ b/networking/models.py
@@ -3,8 +3,8 @@ from typing import *
 
 
 class Player:
-    def __init__(self, _id: int):
-        self._id: int = _id
+    def __init__(self, player_id: int):
+        self._id: int = player_id
 
         self._username: Optional[str] = None
         self._position: Optional[List[int]] = None

--- a/networking/models.py
+++ b/networking/models.py
@@ -1,14 +1,14 @@
 import random
 from typing import *
 
+
 class Player:
-    def __init__(self, player_id):
+    def __init__(self, _id: int):
+        self._id: int = _id
+
         self._username: Optional[str] = None
         self._position: Optional[List[int]] = None
-
-        self._id: Optional[int] = None
         self._char: Optional[chr] = None
-        self._assign_id(player_id)
 
     def ready(self) -> bool:
         return None not in (self._username, self._position, self._id, self._char)

--- a/networking/payload.py
+++ b/networking/payload.py
@@ -1,5 +1,5 @@
 from typing import *
-import pickle
+import json
 
 
 class Payload:
@@ -7,7 +7,20 @@ class Payload:
         self.value: Any = value
 
     def serialize(self):
-        return pickle.dumps(self.value).hex()
+        def default(o):
+            if hasattr(o, '__dict__'):
+                data = o.__dict__
+                o['classkey'] = o.__class__.__name__
+                return data
+            else:
+                return o
+
+        if hasattr(self.value, '__dict__'):
+            data = json.dumps(self.value.__dict__, default=default, separators=(',', ': '))
+            data = data[:1] + f'"classkey":"{self.value.__class__.__name__}",' + data[1:]
+            return data
+        else:
+            return json.dumps(self.value, default=default, separators=(',', ': '))
 
     def __repr__(self):
         return f"(Payload: {self.value})"


### PR DESCRIPTION
This is done and you can checkout MM-28 to have a look but the implementation has a bit of a side effect which I want to fix.

The serialization works great, it recursively generates json for objects including a “classkey” attribute which includes the name of the class.

Deserialization is the problem. It first pops off the classkey attribute, and then saves the other attributes that make up the object to construct. It uses the inspect library to infer the class’s constructor arguments and then compares those to the names of the attributes to decide how to make the constructor call to get the object and return it.

Only problem is, by comparing the constructor arguments to the attributes, we require the argument name to equal what we end up calling the attribute, i.e. you can’t have something like this:

```python
class Player:
    def __init__(self, player_id):
        self._id = player_id
        ...
```
because “player_id” != “_id”.

In fact, to get around this, I would need to temporarily call the argument “_id” which you can see in networking/models.py of c04b141952e487be0c5a20a5e51ebac6b5a36545.

I decided it’s a bit less horrible to just initialise everything with None as all the arguments, and then go through and set the attributes of everything else after the “shell” of the object’s been created.

This has its own problems but I feel they are less likely.

If an object’s constructor contains logic / processing with arguments that simply won’t work when None is provided, an exception will be thrown and the processing won’t be done.

I feel that it is bad design to do logic / processing in a constructor anyway but that might be just me.

For example:
```python
class Player:
  def __init__(self, player_id):
    self._id = player_id % 10
```
(I know it’s a contrived example, I don’t know why anybody would do this but you get the point).

This was done in 01b7a360f67d8cfc85ec9d29d2d542e165116885

For now, I’m happy to say this is fine and forget about it until something breaks and then I’m happy to revisit.